### PR TITLE
feat: bulk_discounts index page

### DIFF
--- a/app/controllers/merchant_bulk_discounts_controller.rb
+++ b/app/controllers/merchant_bulk_discounts_controller.rb
@@ -1,0 +1,12 @@
+class MerchantBulkDiscountsController < ApplicationController
+  before_action :set_merchant, only: [:index]
+  
+  def index
+  end
+
+  private
+
+  def set_merchant
+    @merchant = Merchant.find(params[:merchant_id])
+  end
+end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -2,11 +2,13 @@ class Merchant < ApplicationRecord
 
   enum status: { disabled: 0, enabled: 1 }
   
+  has_many :bulk_discounts, dependent: :destroy
   has_many :items, dependent: :destroy 
   has_many :invoice_items, through: :items
   has_many :invoices, through: :items
   has_many :customers, through: :invoices
   has_many :transactions, through: :invoices
+
 
   validates :name, presence: true
 

--- a/app/views/merchant_bulk_discounts/index.html.erb
+++ b/app/views/merchant_bulk_discounts/index.html.erb
@@ -1,0 +1,25 @@
+<%= render partial: "merchants/header", locals: {merchant: @merchant} %>
+
+<div class="container">
+  <div class="row pb-5">
+    <div class="col">
+      <h2>Bulk Discounts</h2>
+    </div>
+  </div>
+  <div class="row row-cols-2 row-cols-md-3">
+    <% @merchant.bulk_discounts.each do |bd| %>
+      <div class="col-6 col-md-4">
+        <div class="card" id="bulk_discount_<%= bd.id %>">
+          <div class="card-body">
+            <%= link_to merchant_bulk_discount_path(@merchant, bd), class: "card-link" do %>
+              <h4 class="card-title">Discount <%= bd.id %></h4>
+            <% end %>
+            <p class="card-text">
+              <b><%= bd.discount %>%</b> off purchases of <b><%= bd.quantity %></b> or more items.
+            </p>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -3,6 +3,9 @@
 <%# image_tag(@merchant_photo.url["thumb"]) %>
 
 <div class="container">
+  <div class="row">
+    <%= link_to "View Discounts", merchant_bulk_discounts_path(@merchant) %>
+  </div>
   <div class="row pb-5">
     <div id="items_to_be_shipped" class="col">
       <div class="text-center bg-dark-subtle border-top border-black border-5 p-2 mb-4">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,10 +12,9 @@ Rails.application.routes.draw do
 
   resources :merchants, only: :show do
     get "/dashboard", to: "merchants#show"
-
     resources :items, except: [:destroy], controller: "merchant_items"
-
-    resources :invoices, only: [:index, :show], controller: "merchant_invoices" 
+    resources :invoices, only: [:index, :show], controller: "merchant_invoices"
+    resources :bulk_discounts, only: [:index, :show], controller: "merchant_bulk_discounts"
   end
 
   resources :invoice_items, only: [:update], controller: "merchant_invoice_items"

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper" 
+
+RSpec.describe "Bulk Discounts Index Page" do
+  before :each do
+    @merchant = Merchant.create!(name: "Ethan Inc.")
+
+    @discount1 = @merchant.bulk_discounts.create!(discount: 15, quantity: 10)
+    @discount2 = @merchant.bulk_discounts.create!(discount: 20, quantity: 15)
+    @discount3 = @merchant.bulk_discounts.create!(discount: 25, quantity: 20)
+
+    visit merchant_bulk_discounts_path(@merchant)
+  end
+
+
+  it "lists every bulk discount with its percentage discount and quantity threshold for a merchant" do
+    within("#bulk_discount_#{@discount1.id}") do
+      expect(page).to have_content("Discount #{@discount1.id}").once
+      expect(page).to have_content("#{@discount1.discount}%").once
+      expect(page).to have_content(@discount1.quantity).once
+    end
+    
+    within("#bulk_discount_#{@discount2.id}") do
+      expect(page).to have_content("Discount #{@discount2.id}").once
+      expect(page).to have_content("#{@discount2.discount}%").once
+      expect(page).to have_content(@discount2.quantity).once
+    end
+    
+    within("#bulk_discount_#{@discount3.id}") do
+      expect(page).to have_content("Discount #{@discount3.id}").once
+      expect(page).to have_content("#{@discount3.discount}%").once
+      expect(page).to have_content(@discount3.quantity).once
+    end
+  end
+
+  it "each bulk discount listed includes a link to its show page" do
+    save_and_open_page
+    expect(page).to have_link(href: merchant_bulk_discount_path(@merchant, @discount1)).once
+  
+    expect(page).to have_link(href: merchant_bulk_discount_path(@merchant, @discount2)).once
+  
+    expect(page).to have_link(href: merchant_bulk_discount_path(@merchant, @discount3)).once
+  end
+end

--- a/spec/features/merchants/merchant_dashboard_spec.rb
+++ b/spec/features/merchants/merchant_dashboard_spec.rb
@@ -231,4 +231,15 @@ RSpec.describe "Merchant Dashboard Page", type: :feature do
       end
     end
   end
+
+  # SOLO PROJECT BULK DISCOUNTS STORY 1
+  it "has a link to view all discounts" do
+    visit merchant_dashboard_path(@merchant_1)
+    
+    expect(page).to have_link("View Discounts", href: merchant_bulk_discounts_path(@merchant_1)).once
+
+    click_link("View Discounts", href: merchant_bulk_discounts_path(@merchant_1))
+
+    expect(current_path).to eq(merchant_bulk_discounts_path(@merchant_1))
+  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Merchant, type: :model do
 
   describe "relationships" do
     it {should have_many :items}
+    it {should have_many :bulk_discounts}
     it {should have_many(:invoice_items).through(:items)}
     it {should have_many(:invoices).through(:items)}
     it {should have_many(:customers).through(:invoices)}


### PR DESCRIPTION
Adds the bulk_discounts index page for user story 1.

I used some fancy Bootstrap card layouts for the page, too, so it looks extra nice.
![Screenshot 2023-08-03 at 6 54 35 PM](https://github.com/ethanrossblack/little-shop-7-ethan/assets/8324716/9eb89304-559e-4922-81ec-b348aaa07061)

```
1: Merchant Bulk Discounts Index

As a merchant
When I visit my merchant dashboard
Then I see a link to view all my discounts
When I click this link
Then I am taken to my bulk discounts index page
Where I see all of my bulk discounts including their
percentage discount and quantity thresholds
And each bulk discount listed includes a link to its show page
```