### PR TITLE
11 story 7 merchant invoice show page link to applied discounts

### DIFF
--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -23,6 +23,7 @@
               <th>Item Name</th>
               <th>Quantity</th>
               <th>Unit Price</th>
+              <th>Applied Discount</th>
               <th>Status</th>
             </tr>
           </thead>
@@ -32,14 +33,19 @@
                 <td><%= invoice_item.item.name %></td>
                 <td class="quantity"><%= invoice_item.quantity %></td>
                 <td class="price"><%= number_to_currency(invoice_item.dollar_price) %></td>
+                <td id="invoice_item_<%= invoice_item.id %>_discount">
+                  <% if invoice_item.best_bulk_discount %>
+                    <%= link_to "Discount #{invoice_item.best_bulk_discount.id}", merchant_bulk_discount_path(@merchant, invoice_item.best_bulk_discount) %>
+                  <% end %>
+                </td>
                 <td id="invoice_item_status_<%= invoice_item.id %>">
                   <%= form_with model: invoice_item, method: :patch, local: true do |form| %>
                     <%= form.hidden_field :invoice_id, value: @invoice.id %>
                     <%= form.hidden_field :merchant_id, value: @merchant.id %>
                     <div class="col-auto">
-                    <%= form.select(:status, [["Pending", "pending"], ["Packaged", "packaged"], ["Shipped", "shipped"]], { selected: invoice_item.status}, { class: "form-select col-auto" }) %>
+                      <%= form.select(:status, [["Pending", "pending"], ["Packaged", "packaged"], ["Shipped", "shipped"]], { selected: invoice_item.status}, { class: "form-select col-auto" }) %>
 
-                    <%= form.submit "Update Item Status" %>
+                      <%= form.submit "Update Item Status" %>
                     </div>
                   <% end %>
                 </td>

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -42,11 +42,8 @@
                   <%= form_with model: invoice_item, method: :patch, local: true do |form| %>
                     <%= form.hidden_field :invoice_id, value: @invoice.id %>
                     <%= form.hidden_field :merchant_id, value: @merchant.id %>
-                    <div class="col-auto">
-                      <%= form.select(:status, [["Pending", "pending"], ["Packaged", "packaged"], ["Shipped", "shipped"]], { selected: invoice_item.status}, { class: "form-select col-auto" }) %>
-
-                      <%= form.submit "Update Item Status" %>
-                    </div>
+                    <%= form.select(:status, [["Pending", "pending"], ["Packaged", "packaged"], ["Shipped", "shipped"]], { selected: invoice_item.status}) %>
+                    <%= form.submit "Update Item Status" %>
                   <% end %>
                 </td>
               </tr>

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe "Merchant Invoice Show Page", type: :feature do
     end
     # ======= END STORY 18 TESTS =======
 
-    # === Start Bulk Discount Story 6 Tests ===
+    # === Bulk Discount Tests ===
     describe "Bulk Discount Application" do
       before :each do
         # Merchants
@@ -236,8 +236,9 @@ RSpec.describe "Merchant Invoice Show Page", type: :feature do
 
         @invoice_item_1_1b = create(:invoice_item, quantity: 2, unit_price: @item_1b.unit_price, item_id: @item_1b.id, invoice_id: @invoice_1.id)
       end
-
-      it "the total discounted revenue for a merchant from an invoice which includes bulk discounts in the calculation" do
+      
+      # === Start Bulk Discount Story 6 Tests ===
+      it "displays the total discounted revenue for a merchant from an invoice which includes bulk discounts in the calculation" do
         visit merchant_invoice_path(@merchant_a, @invoice_1)
 
         expected = ActiveSupport::NumberHelper::number_to_currency(@invoice_1.merchant_discounted_revenue_dollars(@merchant_a.id))
@@ -246,7 +247,28 @@ RSpec.describe "Merchant Invoice Show Page", type: :feature do
           expect(page).to have_content(expected)
         end
       end
+      # === End Bulk Discount Story 6 Tests ===
+      
+      # === Start Bulk Discount Story 7 Tests ===
+      it "displays next to every discounted invoice item a link to the applied bulk discount show page" do
+        visit merchant_invoice_path(@merchant_a, @invoice_1)
+        
+        within("#invoice_item_#{@invoice_item_1_1a.id}_discount") do
+          expect(page).to have_link(href: merchant_bulk_discount_path(@merchant_a, @discount_1a))
+        end
+        
+        within("#invoice_item_#{@invoice_item_1_3a.id}_discount") do
+          expect(page).to have_link(href: merchant_bulk_discount_path(@merchant_a, @discount_2a))
+        end
+      end
+      
+      
+      
+      
+      # === End Bulk Discount Story 7 Tests ===
+
     end
-    # === End Bulk Discount Story 6 Tests ===
+
+
   end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -261,14 +261,7 @@ RSpec.describe "Merchant Invoice Show Page", type: :feature do
           expect(page).to have_link(href: merchant_bulk_discount_path(@merchant_a, @discount_2a))
         end
       end
-      
-      
-      
-      
       # === End Bulk Discount Story 7 Tests ===
-
     end
-
-
   end
 end


### PR DESCRIPTION
complete story 7, fixed some formatting

```
7: Merchant Invoice Show Page: Link to applied discounts

As a merchant
When I visit my merchant invoice show page
Next to each invoice item I see a link to the show page for the bulk discount that was applied (if any)
```