### PR TITLE
13 story 9 holidays api

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,9 @@ GEM
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.2.1)
@@ -139,6 +142,7 @@ GEM
     mini_mime (1.1.2)
     minitest (5.18.1)
     msgpack (1.7.1)
+    multi_xml (0.6.0)
     net-imap (0.3.6)
       date
       net-protocol
@@ -283,6 +287,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   faraday
+  httparty
   importmap-rails
   jbuilder
   launchy

--- a/app/controllers/merchant_bulk_discounts_controller.rb
+++ b/app/controllers/merchant_bulk_discounts_controller.rb
@@ -3,6 +3,7 @@ class MerchantBulkDiscountsController < ApplicationController
   before_action :set_merchant_and_bulk_discount, only: [:destroy, :show]
   
   def index
+    @holidays = HolidayService.new.get_next_3_holidays
   end
 
   def new

--- a/app/poros/holiday.rb
+++ b/app/poros/holiday.rb
@@ -1,0 +1,8 @@
+class Holiday
+  attr_reader :name, :date
+
+  def initialize(data)
+    @name = data[:localName]
+    @date = Date.parse(data[:date])
+  end
+end

--- a/app/services/holiday_service.rb
+++ b/app/services/holiday_service.rb
@@ -1,0 +1,21 @@
+require "faraday"
+require "./app/poros/holiday"
+
+class HolidayService
+  def get_next_3_holidays
+    response = connection.get
+    parsed = JSON.parse(response.body, symbolize_names: true)
+
+    holidays = []
+    i = 0
+    3.times do
+      holidays << Holiday.new(parsed[i])
+      i += 1
+    end
+    holidays
+  end
+
+  def connection
+    Faraday.new(url:"https://date.nager.at/api/v3/NextPublicHolidays/US")
+  end
+end

--- a/app/views/merchant_bulk_discounts/index.html.erb
+++ b/app/views/merchant_bulk_discounts/index.html.erb
@@ -28,4 +28,17 @@
       </div>
     <% end %>
   </div>
+  <div class="row">
+    <div class="col" id="upcoming-holidays">
+      <h2>Upcoming Holidays</h2>
+      <ul>
+      <% @holidays.each do |h| %>
+        <li class="holiday">
+          <p class="holiday_name"><%= "#{h.name}" %></p>
+          <p class="holiday_date"><%= "#{h.date.to_fs(:long_ordinal)}" %></p>
+        </li>
+      <% end %>
+      <ul>
+    </div>
+  </div>
 </div>

--- a/spec/features/admin/admin_invoice_show_spec.rb
+++ b/spec/features/admin/admin_invoice_show_spec.rb
@@ -118,8 +118,6 @@ RSpec.describe "Admin Invoice Show Page", type: :feature do
     it "displays the total discounted revenue from this invoice which includes bulk discounts in the calculation" do
       visit admin_invoice_path(@invoice_01)
 
-      save_and_open_page
-
       expected = ActiveSupport::NumberHelper::number_to_currency(@invoice_01.discounted_revenue_dollars)
 
       within("#invoice_discounted_revenue") do

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -59,6 +59,19 @@ RSpec.describe "Bulk Discounts Index Page" do
     within("#bulk_discounts") do
       expect(page).to_not have_content("Discount #{@discount1.id}")
       expect(page).to_not have_content("#{@discount1.discount}% off purchases of #{@discount1.quantity} or more items.")
+    end
   end
+
+  it "has a section labeled 'Upcoming Holidays' for the next three upcoming holidays in the US" do
+    within("#upcoming-holidays") do
+      expect(page).to have_content("Upcoming Holidays")
+
+      expect(page).to have_css(".holiday", count: 3)
+
+      within(first(".holiday")) do
+        expect(page).to have_css(".holiday_name")
+        expect(page).to have_css(".holiday_date")
+      end
+    end
   end
 end


### PR DESCRIPTION
complete story 9, incorporate the holidays API into the site

```
9: Holidays API

As a merchant
When I visit the discounts index page
I see a section with a header of "Upcoming Holidays"
In this section the name and date of the next 3 upcoming US holidays are listed.

Use the Next Public Holidays Endpoint in the [Nager.Date API](https://date.nager.at/swagger/index.html)
```