### PR TITLE
9 story 5 merchant bulk discount edit

### DIFF
--- a/app/controllers/merchant_bulk_discounts_controller.rb
+++ b/app/controllers/merchant_bulk_discounts_controller.rb
@@ -1,6 +1,6 @@
 class MerchantBulkDiscountsController < ApplicationController
   before_action :set_merchant, only: [:index, :new, :create]
-  before_action :set_merchant_and_bulk_discount, only: [:destroy, :show]
+  before_action :set_merchant_and_bulk_discount, only: [:destroy, :show, :edit]
   
   def index
     @holidays = HolidayService.new.get_next_3_holidays
@@ -19,6 +19,10 @@ class MerchantBulkDiscountsController < ApplicationController
       flash[:alert] = "Error: #{error_message(bulk_discount.errors)}."
       redirect to new_merchant_bulk_discount_path
     end
+  end
+
+  def edit
+
   end
 
   def destroy

--- a/app/controllers/merchant_bulk_discounts_controller.rb
+++ b/app/controllers/merchant_bulk_discounts_controller.rb
@@ -1,6 +1,6 @@
 class MerchantBulkDiscountsController < ApplicationController
   before_action :set_merchant, only: [:index, :new, :create]
-  before_action :set_merchant_and_bulk_discount, only: [:destroy, :show, :edit]
+  before_action :set_merchant_and_bulk_discount, only: [:destroy, :show, :edit, :update]
   
   def index
     @holidays = HolidayService.new.get_next_3_holidays
@@ -22,7 +22,16 @@ class MerchantBulkDiscountsController < ApplicationController
   end
 
   def edit
+  end
 
+  def update
+    if @bulk_discount.update(bulk_discount_params)
+      redirect_to merchant_bulk_discount_path(@merchant, @bulk_discount)
+      flash[:success] = "Bulk Discount Successfully Updated"
+    else
+      redirect_to edit_merchant_bulk_discount_path(@merchant, @bulk_discount)
+      flash[:alert] = "Error: #{error_message(@bulk_discount.errors)}"
+    end
   end
 
   def destroy

--- a/app/views/merchant_bulk_discounts/edit.html.erb
+++ b/app/views/merchant_bulk_discounts/edit.html.erb
@@ -1,0 +1,22 @@
+<div class="container">
+  <h2>Edit Discount <%= @bulk_discount.id %></h2>
+  <%= form_with model: @bulk_discount, url: merchant_bulk_discount_path(@merchant, @bulk_discount), id: "new_bulk_discount_form", local: true do |f| %>
+    <div class="row">
+      <div class="col-auto">
+        <%= f.label :discount, class: "form-label" %>
+        <div class="input-group mb-3">
+          <%= f.number_field :discount, in: 1..100, class: "form-control" %>
+          <span class="input-group-text">% off</span>
+        </div>
+      </div>
+      <div class="col-auto">
+        <%= f.label :quantity, class: "form-label" %>
+        <div class="input-group mb-3">
+          <%= f.number_field :quantity, class: "form-control" %>
+          <span class="input-group-text">items or more</span>
+        </div>
+      </div>
+    </div>
+    <%= f.button "Edit Bulk Discount", class: "btn btn-primary" %>
+  <% end %>
+</div>

--- a/app/views/merchant_bulk_discounts/show.html.erb
+++ b/app/views/merchant_bulk_discounts/show.html.erb
@@ -6,6 +6,7 @@
       <h2>Discount <%= @bulk_discount.id %></h2>
       <p class="bulk_discount_percentage"><b>Percentage Discount:</b> <%= @bulk_discount.discount %>%</p>
       <p class="bulk_discount_quantity"><b>Quantity Threshold:</b> <%= @bulk_discount.quantity %></p>
+      <%= link_to "Edit Bulk Discount", edit_merchant_bulk_discount_path(@merchant, @bulk_discount), class: "btn btn-primary mt-3"%>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     get "/dashboard", to: "merchants#show"
     resources :items, except: [:destroy], controller: "merchant_items"
     resources :invoices, only: [:index, :show], controller: "merchant_invoices"
-    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy], controller: "merchant_bulk_discounts"
+    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy, :edit], controller: "merchant_bulk_discounts"
   end
 
   resources :invoice_items, only: [:update], controller: "merchant_invoice_items"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     get "/dashboard", to: "merchants#show"
     resources :items, except: [:destroy], controller: "merchant_items"
     resources :invoices, only: [:index, :show], controller: "merchant_invoices"
-    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy, :edit], controller: "merchant_bulk_discounts"
+    resources :bulk_discounts, controller: "merchant_bulk_discounts"
   end
 
   resources :invoice_items, only: [:update], controller: "merchant_invoice_items"

--- a/spec/features/merchants/bulk_discounts/edit_spec.rb
+++ b/spec/features/merchants/bulk_discounts/edit_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe "Bulk Discount Edit Page", type: :feature do
+  before :each do
+    @merchant = Merchant.create!(name: "Ethan Inc.")
+    @discount = @merchant.bulk_discounts.create!(discount: 15, quantity: 10)
+
+    visit edit_merchant_bulk_discount_path(@merchant, @discount)
+  end
+
+  it "pre-populates the bulk discount's current attributes in the form" do
+    within("#new_bulk_discount_form") do
+      expect(page).to have_field("Discount", with: @discount.discount)
+      expect(page).to have_field("Quantity", with: @discount.quantity)
+    end
+  end
+
+  describe "when I change any/all of the information and click submit" do
+    before :each do
+      fill_in("Discount", with: "50")
+      fill_in("Quantity", with: "30")
+
+      click_button("Edit Bulk Discount")
+    end
+
+    it "then I am redirected to the bulk discount's show page" do
+      expect(current_path).to eq(merchant_bulk_discount_path(@merchant, @discount))
+    end
+
+    it "and I see that the discount's attributes have been updated" do
+      @discount.reload
+      
+      within(".bulk_discount_quantity") do
+        expect(page).to have_content("30").once
+      end
+  
+      within(".bulk_discount_percentage") do
+        expect(page).to have_content("50").once
+      end
+    end
+  end
+end

--- a/spec/features/merchants/bulk_discounts/show_spec.rb
+++ b/spec/features/merchants/bulk_discounts/show_spec.rb
@@ -17,4 +17,12 @@ RSpec.describe "Bulk Discount Show Page", type: :feature do
       expect(page).to have_content(@discount.discount).once
     end
   end
+
+  it "has a link to edit the bulk discount that tales you to a new page with a form to edit the bulk discount" do
+    expect(page).to have_link("Edit Bulk Discount")
+
+    click_link("Edit Bulk Discount")
+
+    expect(current_path).to eq(edit_merchant_bulk_discount_path(@merchant, @discount))
+  end
 end


### PR DESCRIPTION
complete story 5

```
5: Merchant Bulk Discount Edit

As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated
```